### PR TITLE
Add GitHub Skills activity to extracurricular programs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications program",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the GitHub Skills activity that was announced by the school principal but missing from the activities signup page.

## Resolves
Fixes #6 🚨 Missing Activity: GitHub Skills

## Changes Made
- Added "GitHub Skills" activity to the activities list
- Configured schedule: Mondays and Thursdays, 3:30 PM - 4:30 PM
- Set max participants to 25
- Included reference to GitHub Certifications program in description

## Why This is Important
This was a time-sensitive request from a student (Hewbie C., 11th Grade) noting that:
- The principal announced a GitHub Skills partnership
- Registration deadline is end of this week
- The activity is critical for the GitHub Certifications program which helps with college applications
- Students were unable to register because the activity wasn't in the system

## Testing
- Activity now appears in the activities list endpoint
- Students can now sign up for GitHub Skills activity
- No breaking changes to existing functionality